### PR TITLE
Fix: Remove unused pytest import

### DIFF
--- a/tests/integration/test_with_clause.py
+++ b/tests/integration/test_with_clause.py
@@ -7,8 +7,6 @@ The WITH clause enables query chaining, allowing you to:
 - Order and limit intermediate results
 """
 
-import pytest
-
 from graphforge import GraphForge
 
 


### PR DESCRIPTION
## Summary

Remove unused `pytest` import from WITH clause integration tests that was causing lint failure.

## Problem

Lint check failing on main with:
```
F401 [*] `pytest` imported but unused
  --> tests/integration/test_with_clause.py:10:8
```

## Solution

Remove the unused import. The test file doesn't actually need pytest imported directly - it only needs GraphForge.

## Testing

- Lint check should pass
- Tests still run correctly (pytest is invoked by test runner, not imported)

## Checklist

- [x] Fix applied
- [x] No functional changes
- [x] Tests unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unused test dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->