### PR TITLE
chore: add PyPI classifiers for Python version support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,18 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "David Spencer" }]
 keywords = ["graph", "opencypher", "pydantic", "analysis"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+]
 
 dependencies = [
   "pydantic>=2.6",


### PR DESCRIPTION
Adds PyPI classifiers to pyproject.toml to display Python version support (3.10-3.13) on the PyPI package page and README badge.

## Changes
- Add classifiers section to pyproject.toml with:
  - Development Status: Alpha
  - License: MIT
  - Python versions: 3.10, 3.11, 3.12, 3.13
  - Topic classifiers for package categorization

## Impact
- Python version badge on README will display supported versions once published to PyPI
- Package will appear in PyPI searches for Python 3.10+ projects
- Improves package discoverability and documentation

No functional changes - metadata only.