### PR TITLE
fix: update to codecov-action@v5 for test analytics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,13 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: test-results-unit.xml,test-results-integration.xml
           flags: ${{ matrix.os }}-py${{ matrix.python-version }}
+          report_type: test_results
           fail_ci_if_error: false
 
   lint:
@@ -163,12 +164,13 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: test-results-full.xml
           flags: full-suite
+          report_type: test_results
           fail_ci_if_error: false
 
       - name: Upload coverage artifacts


### PR DESCRIPTION
Fixes deprecation warning by updating from `test-results-action@v1` to `codecov-action@v5` with `report_type: test_results`.

## Problem

After PR #17 merged, CI logs show this deprecation warning:

```
##[warning]This action is being deprecated in favor of 'codecov-action'.
Please update CI accordingly to use 'codecov-action@v5' with
'report_type: test_results'.
```

## Solution

Update to the new recommended approach: use `codecov-action@v5` for both coverage **and** test results uploads, differentiated by the `report_type` parameter.

## Changes

### Test Job
**Before:**
```yaml
- uses: codecov/test-results-action@v1
  with:
    files: test-results-unit.xml,test-results-integration.xml
```

**After:**
```yaml
- uses: codecov/codecov-action@v5
  with:
    files: test-results-unit.xml,test-results-integration.xml
    report_type: test_results
```

### Coverage Job
Same update applied to the full test suite upload.

## Impact

- ✅ Removes deprecation warning
- ✅ Uses officially recommended action
- ✅ No functional changes - test analytics still work
- ✅ Future-proof for continued Codecov support

## Testing

The test analytics functionality was verified in PR #17:
- Test results successfully uploaded
- "Process Upload complete" confirmed in logs
- 2 test result files reported correctly

This PR only changes the action used, not the functionality.

## Related

- Fixes deprecation introduced in PR #17
- Follows Codecov's official migration guide

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>