### PR TITLE
chore: migrate to modern GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -43,10 +50,10 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Upload documentation artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: documentation
           path: site/
 
   deploy:
@@ -55,28 +62,11 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Install documentation dependencies
-        run: |
-          uv pip install --system -e ".[docs]"
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy documentation
-        run: mkdocs gh-deploy --force --clean --verbose
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Migrates documentation deployment from legacy `mkdocs gh-deploy` to modern GitHub Actions native deployment using `actions/upload-pages-artifact` and `actions/deploy-pages`.

## Changes

**Before:**
- Used `mkdocs gh-deploy` which requires git configuration and pushes to `gh-pages` branch
- Requires `contents: write` permission
- Deploy job rebuilds docs and deploys (duplicate work)

**After:**
- Uses `actions/upload-pages-artifact` in build job
- Uses `actions/deploy-pages` in deploy job  
- Requires `pages: write` and `id-token: write` permissions
- Deploy job is just 2 lines - much simpler!
- No git configuration needed
- No dependency on `gh-pages` branch

## Benefits

- ✅ **Simpler**: Deploy step is just 2 lines vs 30+ lines
- ✅ **Faster**: No need to rebuild docs in deploy job
- ✅ **Modern**: Follows current GitHub recommendations
- ✅ **Secure**: Uses id-token for deployment authentication
- ✅ **Cleaner**: No `gh-pages` branch needed

## Next Steps

Once this is merged and verified working:
1. Delete the legacy `gh-pages` branch: `git push origin --delete gh-pages`
2. Documentation will be served from: https://decisionnerd.github.io/graphforge/

## Testing

- GitHub Pages has been configured with `build_type: workflow`
- Deployment will trigger on merge to main