### PR TITLE
fix: ORDER BY after aggregation now finds aliased variables (issue #36)

### DIFF
--- a/tests/integration/test_sort_after_aggregation.py
+++ b/tests/integration/test_sort_after_aggregation.py
@@ -1,0 +1,297 @@
+"""Integration tests for ORDER BY after aggregation (issue #36).
+
+Tests for ORDER BY working correctly after WITH + aggregation.
+"""
+
+from graphforge import GraphForge
+
+
+class TestSortAfterAggregation:
+    """Tests for ORDER BY after aggregation."""
+
+    def test_order_by_aggregated_column(self):
+        """ORDER BY on aggregated column."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Sale {product: 'A', amount: 100}),
+                   (b:Sale {product: 'A', amount: 150}),
+                   (c:Sale {product: 'B', amount: 200}),
+                   (d:Sale {product: 'C', amount: 50})
+        """)
+
+        results = gf.execute("""
+            MATCH (s:Sale)
+            WITH s.product AS product, SUM(s.amount) AS total
+            ORDER BY total DESC
+            RETURN product, total
+        """)
+
+        assert len(results) == 3
+        assert results[0]["product"].value == "A"
+        assert results[0]["total"].value == 250
+        assert results[1]["product"].value == "B"
+        assert results[1]["total"].value == 200
+        assert results[2]["product"].value == "C"
+        assert results[2]["total"].value == 50
+
+    def test_order_by_grouping_column(self):
+        """ORDER BY on grouping column (not aggregated)."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {category: 'Z', val: 10}),
+                   (b:Item {category: 'A', val: 20}),
+                   (c:Item {category: 'M', val: 30})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.category AS cat, COUNT(i) AS count
+            ORDER BY cat ASC
+            RETURN cat, count
+        """)
+
+        assert len(results) == 3
+        assert results[0]["cat"].value == "A"
+        assert results[1]["cat"].value == "M"
+        assert results[2]["cat"].value == "Z"
+
+    def test_order_by_with_skip_limit(self):
+        """ORDER BY after aggregation with SKIP and LIMIT."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {type: 'A', val: 10}),
+                   (b:Item {type: 'A', val: 20}),
+                   (c:Item {type: 'B', val: 30}),
+                   (d:Item {type: 'B', val: 40}),
+                   (e:Item {type: 'C', val: 50}),
+                   (f:Item {type: 'C', val: 60})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.type AS type, SUM(i.val) AS total
+            ORDER BY total DESC
+            SKIP 1
+            LIMIT 1
+            RETURN type, total
+        """)
+
+        # Order: C(110), B(70), A(30) -> Skip 1 -> Limit 1 -> B(70)
+        assert len(results) == 1
+        assert results[0]["type"].value == "B"
+        assert results[0]["total"].value == 70
+
+    def test_order_by_ascending(self):
+        """ORDER BY ASC after aggregation."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {cat: 'A', val: 100}),
+                   (b:Item {cat: 'B', val: 50}),
+                   (c:Item {cat: 'C', val: 75})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.cat AS category, SUM(i.val) AS total
+            ORDER BY total ASC
+            RETURN category, total
+        """)
+
+        assert len(results) == 3
+        assert results[0]["total"].value == 50
+        assert results[1]["total"].value == 75
+        assert results[2]["total"].value == 100
+
+    def test_order_by_multiple_aggregates(self):
+        """ORDER BY with multiple aggregate functions."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {cat: 'A', val: 10}),
+                   (b:Item {cat: 'A', val: 20}),
+                   (c:Item {cat: 'B', val: 30}),
+                   (d:Item {cat: 'B', val: 40}),
+                   (e:Item {cat: 'C', val: 50})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.cat AS category, COUNT(i) AS count, SUM(i.val) AS total
+            ORDER BY count DESC, total ASC
+            RETURN category, count, total
+        """)
+
+        # A: count=2, total=30
+        # B: count=2, total=70
+        # C: count=1, total=50
+        # Order by count DESC, total ASC: A(2,30), B(2,70), C(1,50)
+        assert len(results) == 3
+        assert results[0]["category"].value == "A"
+        assert results[0]["count"].value == 2
+        assert results[0]["total"].value == 30
+
+    def test_order_by_avg_aggregate(self):
+        """ORDER BY with AVG aggregate."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Student {class: 'A', score: 80}),
+                   (b:Student {class: 'A', score: 90}),
+                   (c:Student {class: 'B', score: 70}),
+                   (d:Student {class: 'B', score: 80}),
+                   (e:Student {class: 'C', score: 95})
+        """)
+
+        results = gf.execute("""
+            MATCH (s:Student)
+            WITH s.class AS class, AVG(s.score) AS avg_score
+            ORDER BY avg_score DESC
+            RETURN class, avg_score
+        """)
+
+        # C: 95, A: 85, B: 75
+        assert len(results) == 3
+        assert results[0]["class"].value == "C"
+        assert results[0]["avg_score"].value == 95.0
+        assert results[1]["class"].value == "A"
+        assert results[1]["avg_score"].value == 85.0
+
+    def test_order_by_min_max(self):
+        """ORDER BY with MIN and MAX aggregates."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {group: 'X', val: 10}),
+                   (b:Item {group: 'X', val: 50}),
+                   (c:Item {group: 'Y', val: 20}),
+                   (d:Item {group: 'Y', val: 60})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.group AS grp, MIN(i.val) AS min_val, MAX(i.val) AS max_val
+            ORDER BY max_val DESC
+            RETURN grp, min_val, max_val
+        """)
+
+        # Y: min=20, max=60
+        # X: min=10, max=50
+        assert len(results) == 2
+        assert results[0]["grp"].value == "Y"
+        assert results[0]["max_val"].value == 60
+
+    def test_order_by_count(self):
+        """ORDER BY with COUNT aggregate."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {type: 'A'}),
+                   (b:Item {type: 'A'}),
+                   (c:Item {type: 'A'}),
+                   (d:Item {type: 'B'}),
+                   (e:Item {type: 'C'}),
+                   (f:Item {type: 'C'})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.type AS type, COUNT(i) AS count
+            ORDER BY count DESC
+            RETURN type, count
+        """)
+
+        # A: 3, C: 2, B: 1
+        assert len(results) == 3
+        assert results[0]["type"].value == "A"
+        assert results[0]["count"].value == 3
+        assert results[1]["type"].value == "C"
+        assert results[1]["count"].value == 2
+
+    def test_order_by_with_where_before_aggregation(self):
+        """ORDER BY after aggregation with WHERE before aggregation."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {cat: 'A', val: 10}),
+                   (b:Item {cat: 'A', val: 20}),
+                   (c:Item {cat: 'B', val: 5}),
+                   (d:Item {cat: 'B', val: 30}),
+                   (e:Item {cat: 'C', val: 50})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WHERE i.val > 10
+            WITH i.cat AS category, SUM(i.val) AS total
+            ORDER BY total DESC
+            RETURN category, total
+        """)
+
+        # After filter: A(20), B(30), C(50)
+        # Aggregated: A: 20, B: 30, C: 50
+        # Ordered DESC: C(50), B(30), A(20)
+        assert len(results) == 3
+        assert results[0]["category"].value == "C"
+        assert results[0]["total"].value == 50
+
+    def test_order_by_without_aggregation_still_works(self):
+        """Ensure ORDER BY without aggregation still works (regression test)."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {name: 'C', val: 3}),
+                   (b:Item {name: 'A', val: 1}),
+                   (c:Item {name: 'B', val: 2})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.name AS name, i.val AS value
+            ORDER BY value ASC
+            RETURN name, value
+        """)
+
+        assert len(results) == 3
+        assert results[0]["name"].value == "A"
+        assert results[0]["value"].value == 1
+        assert results[1]["name"].value == "B"
+        assert results[1]["value"].value == 2
+
+    def test_order_by_alias_defined_in_return(self):
+        """ORDER BY can reference alias defined in RETURN (without aggregation)."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {x: 3}),
+                   (b:Item {x: 1}),
+                   (c:Item {x: 2})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            RETURN i.x AS value
+            ORDER BY value ASC
+        """)
+
+        assert len(results) == 3
+        assert results[0]["value"].value == 1
+        assert results[1]["value"].value == 2
+        assert results[2]["value"].value == 3
+
+    def test_order_by_multiple_columns_after_aggregation(self):
+        """ORDER BY multiple columns after aggregation."""
+        gf = GraphForge()
+        gf.execute("""
+            CREATE (a:Item {cat: 'A', type: 'X', val: 10}),
+                   (b:Item {cat: 'A', type: 'Y', val: 20}),
+                   (c:Item {cat: 'B', type: 'X', val: 30}),
+                   (d:Item {cat: 'B', type: 'Y', val: 40})
+        """)
+
+        results = gf.execute("""
+            MATCH (i:Item)
+            WITH i.cat AS category, i.type AS type, SUM(i.val) AS total
+            ORDER BY category DESC, type ASC
+            RETURN category, type, total
+        """)
+
+        # B,X: 30; B,Y: 40; A,X: 10; A,Y: 20
+        # Order by cat DESC, type ASC: B,X; B,Y; A,X; A,Y
+        assert len(results) == 4
+        assert results[0]["category"].value == "B"
+        assert results[0]["type"].value == "X"
+        assert results[1]["category"].value == "B"
+        assert results[1]["type"].value == "Y"

--- a/tests/integration/test_with_clause_modifiers.py
+++ b/tests/integration/test_with_clause_modifiers.py
@@ -102,11 +102,8 @@ class TestWithClauseModifiers:
         assert len(results) == 3
         assert results[0]["age"].value == 35
 
-    @pytest.mark.skip(
-        reason="Sort after aggregation with original variable names has bug - issue to be filed"
-    )
     def test_with_aggregation_skip_limit(self):
-        """WITH clause with aggregation, SKIP and LIMIT."""
+        """WITH clause with aggregation, ORDER BY, SKIP and LIMIT."""
         gf = GraphForge()
         gf.execute("""
             CREATE (a:Item {cat: 'A', val: 10}),
@@ -125,8 +122,12 @@ class TestWithClauseModifiers:
             RETURN category, total
         """)
 
+        # Order by total DESC: B(70), C(50), A(30)
+        # Skip 1: C(50), A(30)
+        # Limit 1: C(50)
         assert len(results) == 1
-        # Should get the middle value after skipping highest
+        assert results[0]["category"].value == "C"
+        assert results[0]["total"].value == 50
 
     def test_multiple_with_clauses(self, graph_with_numbers):
         """Multiple WITH clauses in a row."""


### PR DESCRIPTION
## Summary

Fixes #36 - ORDER BY now works correctly after WITH clause aggregation by detecting when aliases are already bound in the execution context.

## Problem

When using ORDER BY in a WITH clause after aggregation, the Sort operator failed with:

```
KeyError: 'i'
  File "src/graphforge/executor/executor.py", line 493
    value = evaluate_expression(return_item.expression, ctx)
```

**Example that failed:**
```cypher
MATCH (i:Item)
WITH i.cat AS category, SUM(i.val) AS total
ORDER BY total DESC
SKIP 1
LIMIT 1
RETURN category, total
```

## Root Cause

After the Aggregate operator:
- Input contexts only contain aliases (e.g., `category`, `total`)
- Original variables (e.g., `i`) are no longer available
- Sort operator tried to re-evaluate `return_items` which contained original expressions like `PropertyAccess(variable='i', property='cat')`
- This caused KeyError when trying to access non-existent variables

## Solution

**Smart detection of post-aggregation context:**

```python
# Check if ORDER BY expressions can already be evaluated from input context
# This happens after aggregation where aliases are already bound
skip_return_items_eval = False
if input_rows and op.items:
    try:
        # Try to evaluate all ORDER BY expressions from first context
        for order_item in op.items:
            evaluate_expression(order_item.expression, input_rows[0])
        # If we got here, all ORDER BY expressions are available
        skip_return_items_eval = True
    except (KeyError, AttributeError):
        # Need return_items eval
        skip_return_items_eval = False
```

**Key insight:** After aggregation, aliases are already bound in the context - we don't need (and can't) re-evaluate from return_items.

## Changes

### Modified Files

**`src/graphforge/executor/executor.py`** (lines 474-511)
- Added pre-check: test if ORDER BY expressions exist in current context
- If yes (post-aggregation): skip return_items evaluation
- If no (pre-aggregation): use existing behavior

### Test Files

**Unskipped:** `tests/integration/test_with_clause_modifiers.py::test_with_aggregation_skip_limit`
- Was skipped with "Sort after aggregation with original variable names has bug"
- Now passes with proper assertions

**New:** `tests/integration/test_sort_after_aggregation.py` (12 comprehensive tests)
1. `test_order_by_aggregated_column` - ORDER BY on SUM
2. `test_order_by_grouping_column` - ORDER BY on non-aggregated grouping column
3. `test_order_by_with_skip_limit` - Full pipeline with SKIP/LIMIT
4. `test_order_by_ascending` - ORDER BY ASC
5. `test_order_by_multiple_aggregates` - ORDER BY with multiple sort keys
6. `test_order_by_avg_aggregate` - ORDER BY with AVG
7. `test_order_by_min_max` - ORDER BY with MIN/MAX
8. `test_order_by_count` - ORDER BY with COUNT
9. `test_order_by_with_where_before_aggregation` - WHERE + aggregation + ORDER BY
10. `test_order_by_without_aggregation_still_works` - Regression test
11. `test_order_by_alias_defined_in_return` - ORDER BY with RETURN alias (no agg)
12. `test_order_by_multiple_columns_after_aggregation` - Multi-column ORDER BY

## Test Results

```
✅ 671 tests passed (+13 new tests)
✅ 8 skipped (down from 9)
✅ Coverage: 94.75% (up from 94.65%)
```

All pre-push checks passed:
- Formatting: ✅
- Linting: ✅
- Type checking: ✅
- Coverage threshold: ✅

## Examples Now Working

### Basic aggregation with ORDER BY
```cypher
MATCH (s:Sale)
WITH s.product AS product, SUM(s.amount) AS total
ORDER BY total DESC
RETURN product, total
```

### With SKIP/LIMIT
```cypher
MATCH (i:Item)
WITH i.type AS type, SUM(i.val) AS total
ORDER BY total DESC
SKIP 1
LIMIT 1
RETURN type, total
```

### Multiple aggregates
```cypher
MATCH (i:Item)
WITH i.cat AS category, COUNT(i) AS count, SUM(i.val) AS total
ORDER BY count DESC, total ASC
RETURN category, count, total
```

### All aggregate functions
- ✅ SUM
- ✅ COUNT
- ✅ AVG
- ✅ MIN
- ✅ MAX

## Impact

- **Severity:** Medium bug → Fixed
- **Affected:** WITH clause with aggregation + ORDER BY
- **Workaround removed:** No longer need to avoid ordering after aggregation
- **TCK Impact:** Likely improves compliance for aggregation scenarios
- **Breaking Changes:** None - only fixes broken functionality

## Related Issues

- Found during coverage improvement work (#34)
- Similar pattern to issue #35 (RETURN DISTINCT bug - also fixed)
- Part of v0.2.0 feature set improvements

## Checklist

- [x] Issue #36 resolved
- [x] Unskipped previously failing test
- [x] Added 12 comprehensive tests covering all aggregate functions
- [x] All 671 tests passing
- [x] Coverage improved (94.75%)
- [x] No regressions in existing functionality
- [x] Pre-push checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized ORDER BY query handling for improved performance when sorting results after aggregation operations.

* **Tests**
  * Added comprehensive integration tests covering ORDER BY behavior with various aggregation scenarios, including ordering by aggregated columns, grouping columns, and combined with SKIP/LIMIT operations.
  * Enhanced existing aggregation tests with explicit result verification and ORDER BY validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->