### PR TITLE
feat: implement MERGE ON MATCH SET syntax

### DIFF
--- a/src/graphforge/ast/clause.py
+++ b/src/graphforge/ast/clause.py
@@ -105,11 +105,14 @@ class MergeClause:
     Examples:
         MERGE (n:Person {name: 'Alice'})
         MERGE (n:Person {id: 1}) ON CREATE SET n.created = timestamp()
+        MERGE (n:Person {id: 1}) ON MATCH SET n.updated = timestamp()
+        MERGE (n:Person {id: 1}) ON CREATE SET n.created = 1 ON MATCH SET n.updated = 1
         MERGE (a)-[r:KNOWS]->(b)
     """
 
     patterns: list[Any]  # List of NodePattern or RelationshipPattern
     on_create: "SetClause | None" = None  # Optional ON CREATE SET clause
+    on_match: "SetClause | None" = None  # Optional ON MATCH SET clause
 
 
 @dataclass

--- a/src/graphforge/parser/cypher.lark
+++ b/src/graphforge/parser/cypher.lark
@@ -66,9 +66,10 @@ delete_clause: "DETACH"i "DELETE"i variable ("," variable)*  -> detach_delete
 // MERGE clause
 merge_clause: "MERGE"i pattern ("," pattern)* merge_action*
 
-merge_action: on_create_clause
+merge_action: on_create_clause | on_match_clause
 
 on_create_clause: "ON"i "CREATE"i set_clause
+on_match_clause: "ON"i "MATCH"i set_clause
 
 pattern: node_pattern (relationship_pattern node_pattern)*
 

--- a/src/graphforge/planner/operators.py
+++ b/src/graphforge/planner/operators.py
@@ -234,15 +234,18 @@ class Merge:
     """Operator for merging patterns with conditional SET support.
 
     Creates patterns if they don't exist, or matches them if they do.
-    Optionally executes SET operations only when creating (ON CREATE SET).
+    Optionally executes SET operations when creating (ON CREATE SET) or
+    matching (ON MATCH SET).
 
     Attributes:
         patterns: List of patterns to merge
         on_create: Optional SetClause to execute when creating new elements
+        on_match: Optional SetClause to execute when matching existing elements
     """
 
     patterns: list[Any]  # List of node and relationship patterns to merge
     on_create: Any = None  # Optional SetClause for ON CREATE SET
+    on_match: Any = None  # Optional SetClause for ON MATCH SET
 
 
 @dataclass

--- a/src/graphforge/planner/planner.py
+++ b/src/graphforge/planner/planner.py
@@ -137,7 +137,9 @@ class QueryPlanner:
 
         # 4. MERGE
         for merge in merge_clauses:
-            operators.append(Merge(patterns=merge.patterns, on_create=merge.on_create))
+            operators.append(
+                Merge(patterns=merge.patterns, on_create=merge.on_create, on_match=merge.on_match)
+            )
 
         # 5. WHERE
         if where_clause:

--- a/tests/integration/test_merge_on_match_real.py
+++ b/tests/integration/test_merge_on_match_real.py
@@ -1,0 +1,270 @@
+"""Integration tests for MERGE ON MATCH SET with real-world patterns."""
+
+from graphforge import GraphForge
+
+
+class TestNeo4jTimestampPatterns:
+    """Test timestamp tracking patterns common in Neo4j."""
+
+    def test_timestamp_pattern(self):
+        """Test Neo4j pattern: track creation and last seen timestamps."""
+        gf = GraphForge()
+
+        # First visit - create with timestamp
+        gf.execute("""
+            MERGE (n:User {id: 'user123'})
+            ON CREATE SET n.created = 100
+            ON MATCH SET n.lastSeen = 200
+        """)
+
+        result = gf.execute("""
+            MATCH (n:User {id: 'user123'})
+            RETURN n.created as created, n.lastSeen as lastSeen
+        """)
+        assert result[0]["created"].value == 100
+        assert "lastSeen" not in result[0] or result[0]["lastSeen"].value is None
+
+        # Second visit - update last seen
+        gf.execute("""
+            MERGE (n:User {id: 'user123'})
+            ON CREATE SET n.created = 999
+            ON MATCH SET n.lastSeen = 200
+        """)
+
+        result = gf.execute("""
+            MATCH (n:User {id: 'user123'})
+            RETURN n.created as created, n.lastSeen as lastSeen
+        """)
+        assert result[0]["created"].value == 100  # Original timestamp
+        assert result[0]["lastSeen"].value == 200  # Updated timestamp
+
+    def test_counter_increment_pattern(self):
+        """Test Neo4j pattern: increment counter on match."""
+        gf = GraphForge()
+
+        # Create with initial view count
+        gf.execute("""
+            MERGE (p:Page {url: '/home'})
+            ON CREATE SET p.views = 1
+            ON MATCH SET p.views = 2
+        """)
+
+        result = gf.execute("MATCH (p:Page {url: '/home'}) RETURN p.views as views")
+        assert result[0]["views"].value == 1
+
+        # Subsequent visits increment
+        gf.execute("""
+            MERGE (p:Page {url: '/home'})
+            ON CREATE SET p.views = 1
+            ON MATCH SET p.views = 3
+        """)
+
+        result = gf.execute("MATCH (p:Page {url: '/home'}) RETURN p.views as views")
+        assert result[0]["views"].value == 3
+
+
+class TestStatusTracking:
+    """Test status tracking patterns."""
+
+    def test_status_workflow(self):
+        """Test workflow: create as 'pending', update to 'active' on match."""
+        gf = GraphForge()
+
+        # Create task
+        gf.execute("""
+            MERGE (t:Task {id: 'task1'})
+            ON CREATE SET t.status = 'pending', t.createdAt = 100
+            ON MATCH SET t.status = 'active', t.updatedAt = 200
+        """)
+
+        result = gf.execute("""
+            MATCH (t:Task {id: 'task1'})
+            RETURN t.status as status, t.createdAt as created, t.updatedAt as updated
+        """)
+        assert result[0]["status"].value == "pending"
+        assert result[0]["created"].value == 100
+        assert "updated" not in result[0] or result[0]["updated"].value is None
+
+        # Update task
+        gf.execute("""
+            MERGE (t:Task {id: 'task1'})
+            ON CREATE SET t.status = 'pending', t.createdAt = 999
+            ON MATCH SET t.status = 'active', t.updatedAt = 200
+        """)
+
+        result = gf.execute("""
+            MATCH (t:Task {id: 'task1'})
+            RETURN t.status as status, t.createdAt as created, t.updatedAt as updated
+        """)
+        assert result[0]["status"].value == "active"
+        assert result[0]["created"].value == 100
+        assert result[0]["updated"].value == 200
+
+
+class TestComplexQueries:
+    """Test complex queries with ON MATCH SET."""
+
+    def test_merge_with_return(self):
+        """Test MERGE ON MATCH SET with RETURN clause."""
+        gf = GraphForge()
+
+        # Create
+        result1 = gf.execute("""
+            MERGE (n:Person {id: 1})
+            ON CREATE SET n.created = true
+            ON MATCH SET n.updated = true
+            RETURN n.created as c, n.updated as u
+        """)
+        assert result1[0]["c"].value is True
+        assert "u" not in result1[0] or result1[0]["u"].value is None
+
+        # Match
+        result2 = gf.execute("""
+            MERGE (n:Person {id: 1})
+            ON CREATE SET n.created = false
+            ON MATCH SET n.updated = true
+            RETURN n.created as c, n.updated as u
+        """)
+        assert result2[0]["c"].value is True  # Original value
+        assert result2[0]["u"].value is True  # Now set
+
+    def test_merge_multiple_nodes_with_on_match(self):
+        """Test MERGE with multiple nodes and ON MATCH."""
+        gf = GraphForge()
+
+        # Create two nodes
+        gf.execute("CREATE (a:Node {id: 1}), (b:Node {id: 2})")
+
+        # MERGE both with ON MATCH
+        gf.execute("""
+            MERGE (a:Node {id: 1}), (b:Node {id: 2})
+            ON MATCH SET a.matched = true
+        """)
+
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN n.matched as matched")
+        assert result[0]["matched"].value is True
+
+    def test_merge_on_match_with_where(self):
+        """Test MERGE ON MATCH followed by WHERE filtering."""
+        gf = GraphForge()
+
+        # Create nodes with different status
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON CREATE SET n.status = 'active'
+        """)
+        gf.execute("""
+            MERGE (n:Node {id: 2})
+            ON CREATE SET n.status = 'inactive'
+        """)
+
+        # Update with ON MATCH
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON MATCH SET n.lastChecked = 100
+        """)
+
+        # Query with WHERE
+        result = gf.execute("""
+            MATCH (n:Node)
+            WHERE n.lastChecked = 100
+            RETURN n.id as id, n.status as status
+        """)
+        assert len(result) == 1
+        assert result[0]["id"].value == 1
+        assert result[0]["status"].value == "active"
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_merge_on_match_with_null_value(self):
+        """Test ON MATCH SET can set null values."""
+        gf = GraphForge()
+
+        # Create with value
+        gf.execute("CREATE (n:Node {id: 1, optional: 'value'})")
+
+        # Clear value with ON MATCH SET
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON MATCH SET n.optional = null
+        """)
+
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN n.optional as val")
+        assert result[0]["val"].value is None
+
+    def test_merge_on_match_overwrite_property(self):
+        """Test ON MATCH SET can overwrite existing properties."""
+        gf = GraphForge()
+
+        # Create with initial value
+        gf.execute("CREATE (n:Node {id: 1, value: 'old'})")
+
+        # Overwrite with ON MATCH SET
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON MATCH SET n.value = 'new'
+        """)
+
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN n.value as val")
+        assert result[0]["val"].value == "new"
+
+    def test_merge_idempotency_with_on_match(self):
+        """Test that repeated MERGE with ON MATCH is idempotent for same values."""
+        gf = GraphForge()
+
+        # Create node
+        gf.execute("CREATE (n:Node {id: 1})")
+
+        # Set value multiple times
+        for _ in range(3):
+            gf.execute("""
+                MERGE (n:Node {id: 1})
+                ON MATCH SET n.flag = true
+            """)
+
+        # Should still be one node with flag=true
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN count(n) as count, n.flag as flag")
+        assert result[0]["count"].value == 1
+        assert result[0]["flag"].value is True
+
+
+class TestPerformance:
+    """Test performance characteristics of MERGE ON MATCH SET."""
+
+    def test_bulk_merge_with_on_match(self):
+        """Test bulk MERGE operations with ON MATCH SET."""
+        gf = GraphForge()
+
+        # Create nodes
+        for i in range(50):
+            gf.execute(f"CREATE (n:Node {{id: {i}}})")
+
+        # Update all with ON MATCH
+        for i in range(50):
+            gf.execute(f"""
+                MERGE (n:Node {{id: {i}}})
+                ON MATCH SET n.processed = true
+            """)
+
+        # Verify all updated
+        result = gf.execute("MATCH (n:Node) WHERE n.processed = true RETURN count(n) as count")
+        assert result[0]["count"].value == 50
+
+    def test_alternating_create_and_match(self):
+        """Test alternating between create and match."""
+        gf = GraphForge()
+
+        # Create/match pattern
+        for i in range(10):
+            gf.execute(f"""
+                MERGE (n:Node {{id: 1}})
+                ON CREATE SET n.created = {i}
+                ON MATCH SET n.matched = {i}
+            """)
+
+        # Should have created on first iteration, matched on rest
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN n.created as c, n.matched as m")
+        assert result[0]["c"].value == 0  # Set on first create
+        assert result[0]["m"].value == 9  # Last match value

--- a/tests/unit/executor/test_merge_on_match.py
+++ b/tests/unit/executor/test_merge_on_match.py
@@ -1,0 +1,211 @@
+"""Unit tests for executing MERGE ON MATCH SET."""
+
+from graphforge import GraphForge
+
+
+class TestMergeOnMatchExecution:
+    """Test execution of MERGE with ON MATCH SET."""
+
+    def test_on_match_executes_when_matching(self):
+        """ON MATCH SET should execute when matching existing node."""
+        gf = GraphForge()
+
+        # Create node first
+        gf.execute("CREATE (n:Test {id: 1, value: 'original'})")
+
+        # MERGE with ON MATCH SET should match existing and update
+        gf.execute("MERGE (n:Test {id: 1}) ON MATCH SET n.updated = true")
+
+        result = gf.execute("MATCH (n:Test {id: 1}) RETURN n.updated as val")
+        assert len(result) == 1
+        assert result[0]["val"].value is True
+
+    def test_on_match_not_executed_when_creating(self):
+        """ON MATCH SET should NOT execute when creating new node."""
+        gf = GraphForge()
+
+        # MERGE creates node, should NOT execute ON MATCH SET
+        gf.execute("MERGE (n:Test {id: 1}) ON MATCH SET n.updated = true")
+
+        result = gf.execute("MATCH (n:Test {id: 1}) RETURN n.updated as val")
+        assert len(result) == 1
+        # Property should not be set because node was created, not matched
+        assert "val" not in result[0] or result[0]["val"].value is None
+
+    def test_on_match_multiple_properties(self):
+        """ON MATCH SET with multiple properties."""
+        gf = GraphForge()
+
+        # Create node
+        gf.execute("CREATE (n:Person {id: 1, name: 'Alice'})")
+
+        # MERGE with ON MATCH SET multiple properties
+        gf.execute("""
+            MERGE (n:Person {id: 1})
+            ON MATCH SET n.updated = true, n.counter = 42
+        """)
+
+        result = gf.execute("""
+            MATCH (n:Person {id: 1})
+            RETURN n.updated as updated, n.counter as counter
+        """)
+        assert result[0]["updated"].value is True
+        assert result[0]["counter"].value == 42
+
+    def test_on_match_updates_existing_property(self):
+        """ON MATCH SET can update existing properties."""
+        gf = GraphForge()
+
+        # Create node with initial counter
+        gf.execute("CREATE (n:Node {id: 1, counter: 1})")
+
+        # MERGE with ON MATCH SET to increment
+        gf.execute("MERGE (n:Node {id: 1}) ON MATCH SET n.counter = 2")
+
+        result = gf.execute("MATCH (n:Node {id: 1}) RETURN n.counter as count")
+        assert result[0]["count"].value == 2
+
+    def test_on_match_with_string(self):
+        """ON MATCH SET with string values."""
+        gf = GraphForge()
+
+        # Create node
+        gf.execute("CREATE (m:Movie {title: 'The Matrix'})")
+
+        # Update with ON MATCH SET
+        gf.execute("""
+            MERGE (m:Movie {title: 'The Matrix'})
+            ON MATCH SET m.status = 'watched'
+        """)
+
+        result = gf.execute("MATCH (m:Movie {title: 'The Matrix'}) RETURN m.status as status")
+        assert result[0]["status"].value == "watched"
+
+
+class TestMergeOnCreateAndOnMatch:
+    """Test MERGE with both ON CREATE SET and ON MATCH SET."""
+
+    def test_on_create_executes_when_creating(self):
+        """When creating, ON CREATE SET should execute, not ON MATCH SET."""
+        gf = GraphForge()
+
+        # MERGE creates node
+        gf.execute("""
+            MERGE (n:Person {id: 1})
+            ON CREATE SET n.created = true
+            ON MATCH SET n.updated = true
+        """)
+
+        result = gf.execute("""
+            MATCH (n:Person {id: 1})
+            RETURN n.created as created, n.updated as updated
+        """)
+        assert result[0]["created"].value is True
+        # updated should not be set (node was created, not matched)
+        assert "updated" not in result[0] or result[0]["updated"].value is None
+
+    def test_on_match_executes_when_matching(self):
+        """When matching, ON MATCH SET should execute, not ON CREATE SET."""
+        gf = GraphForge()
+
+        # Create node first
+        gf.execute("CREATE (n:Person {id: 1})")
+
+        # MERGE matches existing node
+        gf.execute("""
+            MERGE (n:Person {id: 1})
+            ON CREATE SET n.created = true
+            ON MATCH SET n.updated = true
+        """)
+
+        result = gf.execute("""
+            MATCH (n:Person {id: 1})
+            RETURN n.created as created, n.updated as updated
+        """)
+        # created should not be set (node was matched, not created)
+        assert "created" not in result[0] or result[0]["created"].value is None
+        assert result[0]["updated"].value is True
+
+    def test_repeated_merge_tracks_state(self):
+        """Test that repeated MERGE correctly tracks create vs match."""
+        gf = GraphForge()
+
+        # First MERGE creates
+        gf.execute("""
+            MERGE (n:Test {id: 1})
+            ON CREATE SET n.created = 'first'
+            ON MATCH SET n.matched = 'never'
+        """)
+
+        result1 = gf.execute("MATCH (n:Test {id: 1}) RETURN n.created as c, n.matched as m")
+        assert result1[0]["c"].value == "first"
+        assert "m" not in result1[0] or result1[0]["m"].value is None
+
+        # Second MERGE matches
+        gf.execute("""
+            MERGE (n:Test {id: 1})
+            ON CREATE SET n.created = 'second'
+            ON MATCH SET n.matched = 'yes'
+        """)
+
+        result2 = gf.execute("MATCH (n:Test {id: 1}) RETURN n.created as c, n.matched as m")
+        assert result2[0]["c"].value == "first"  # Should still be 'first'
+        assert result2[0]["m"].value == "yes"  # Now set by ON MATCH
+
+    def test_on_create_and_match_with_multiple_properties(self):
+        """Both ON CREATE and ON MATCH with multiple properties."""
+        gf = GraphForge()
+
+        # Create with ON CREATE
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON CREATE SET n.created = true, n.createdAt = 100
+            ON MATCH SET n.updated = true, n.updatedAt = 200
+        """)
+
+        result1 = gf.execute("""
+            MATCH (n:Node {id: 1})
+            RETURN n.created as c, n.createdAt as cat, n.updated as u, n.updatedAt as uat
+        """)
+        assert result1[0]["c"].value is True
+        assert result1[0]["cat"].value == 100
+        assert "u" not in result1[0] or result1[0]["u"].value is None
+        assert "uat" not in result1[0] or result1[0]["uat"].value is None
+
+        # Match with ON MATCH
+        gf.execute("""
+            MERGE (n:Node {id: 1})
+            ON CREATE SET n.created = false, n.createdAt = 999
+            ON MATCH SET n.updated = true, n.updatedAt = 200
+        """)
+
+        result2 = gf.execute("""
+            MATCH (n:Node {id: 1})
+            RETURN n.created as c, n.createdAt as cat, n.updated as u, n.updatedAt as uat
+        """)
+        # Original values from creation
+        assert result2[0]["c"].value is True
+        assert result2[0]["cat"].value == 100
+        # New values from match
+        assert result2[0]["u"].value is True
+        assert result2[0]["uat"].value == 200
+
+
+class TestBackwardCompatibility:
+    """Test that existing MERGE behavior is preserved."""
+
+    def test_merge_with_only_on_create_still_works(self):
+        """MERGE with only ON CREATE SET still works."""
+        gf = GraphForge()
+
+        gf.execute("MERGE (n:Test {id: 1}) ON CREATE SET n.val = 1")
+        result = gf.execute("MATCH (n:Test {id: 1}) RETURN n.val as val")
+        assert result[0]["val"].value == 1
+
+    def test_merge_without_on_clauses_still_works(self):
+        """MERGE without ON CREATE or ON MATCH still works."""
+        gf = GraphForge()
+
+        gf.execute("MERGE (n:Test {id: 1})")
+        result = gf.execute("MATCH (n:Test {id: 1}) RETURN count(n) as count")
+        assert result[0]["count"].value == 1

--- a/tests/unit/parser/test_merge_on_match.py
+++ b/tests/unit/parser/test_merge_on_match.py
@@ -1,0 +1,169 @@
+"""Unit tests for parsing MERGE ON MATCH SET syntax."""
+
+from graphforge.ast.clause import MergeClause, SetClause
+from graphforge.ast.expression import Literal, PropertyAccess
+from graphforge.parser.parser import parse_cypher
+
+
+class TestMergeOnMatchParsing:
+    """Test parsing of MERGE with ON MATCH SET clause."""
+
+    def test_merge_on_match_single_property(self):
+        """Parse MERGE with ON MATCH SET single property."""
+        query = "MERGE (n:Person {id: 1}) ON MATCH SET n.updated = true"
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert len(merge.patterns) == 1
+        assert merge.on_create is None
+        assert merge.on_match is not None
+        assert isinstance(merge.on_match, SetClause)
+        assert len(merge.on_match.items) == 1
+
+        # Check the SET item
+        prop_access, value_expr = merge.on_match.items[0]
+        assert isinstance(prop_access, PropertyAccess)
+        assert prop_access.variable == "n"
+        assert prop_access.property == "updated"
+        assert isinstance(value_expr, Literal)
+        assert value_expr.value is True
+
+    def test_merge_on_match_multiple_properties(self):
+        """Parse MERGE with ON MATCH SET multiple properties."""
+        query = """
+        MERGE (n:Person {id: 1})
+        ON MATCH SET n.updated = true, n.counter = 2
+        """
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert merge.on_match is not None
+        assert len(merge.on_match.items) == 2
+
+        # Check first SET item
+        prop_access1, value_expr1 = merge.on_match.items[0]
+        assert prop_access1.variable == "n"
+        assert prop_access1.property == "updated"
+        assert value_expr1.value is True
+
+        # Check second SET item
+        prop_access2, value_expr2 = merge.on_match.items[1]
+        assert prop_access2.variable == "n"
+        assert prop_access2.property == "counter"
+        assert value_expr2.value == 2
+
+    def test_merge_on_create_and_on_match(self):
+        """Parse MERGE with both ON CREATE SET and ON MATCH SET."""
+        query = """
+        MERGE (n:Person {id: 1})
+        ON CREATE SET n.created = true
+        ON MATCH SET n.updated = true
+        """
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert merge.on_create is not None
+        assert merge.on_match is not None
+
+        # Check ON CREATE
+        assert len(merge.on_create.items) == 1
+        prop1, _val1 = merge.on_create.items[0]
+        assert prop1.property == "created"
+
+        # Check ON MATCH
+        assert len(merge.on_match.items) == 1
+        prop2, _val2 = merge.on_match.items[0]
+        assert prop2.property == "updated"
+
+    def test_merge_on_create_and_on_match_multiple_properties(self):
+        """Parse MERGE with both ON CREATE and ON MATCH with multiple properties."""
+        query = """
+        MERGE (n:Person {id: 1})
+        ON CREATE SET n.created = true, n.createdAt = 100
+        ON MATCH SET n.updated = true, n.updatedAt = 200
+        """
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert merge.on_create is not None
+        assert merge.on_match is not None
+        assert len(merge.on_create.items) == 2
+        assert len(merge.on_match.items) == 2
+
+    def test_merge_case_insensitive(self):
+        """Test ON MATCH keywords are case-insensitive."""
+        queries = [
+            "MERGE (n:Test {id: 1}) ON MATCH SET n.val = 1",
+            "MERGE (n:Test {id: 1}) on match set n.val = 1",
+            "MERGE (n:Test {id: 1}) On Match Set n.val = 1",
+            "MERGE (n:Test {id: 1}) oN mAtCh sEt n.val = 1",
+        ]
+
+        for query in queries:
+            ast = parse_cypher(query)
+            merge = ast.clauses[0]
+            assert isinstance(merge, MergeClause)
+            assert merge.on_match is not None
+            assert isinstance(merge.on_match, SetClause)
+
+    def test_merge_without_on_clauses(self):
+        """Parse MERGE without ON CREATE or ON MATCH (backward compatibility)."""
+        query = "MERGE (n:Person {id: 1})"
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert len(merge.patterns) == 1
+        assert merge.on_create is None
+        assert merge.on_match is None
+
+    def test_merge_on_match_with_return(self):
+        """Parse MERGE with ON MATCH SET and RETURN clause."""
+        query = """
+        MERGE (n:Person {id: 1})
+        ON MATCH SET n.updated = true
+        RETURN n
+        """
+        ast = parse_cypher(query)
+
+        # Should have MERGE and RETURN clauses
+        assert len(ast.clauses) == 2
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert merge.on_match is not None
+
+    def test_merge_on_match_with_string_value(self):
+        """Parse MERGE with ON MATCH SET with string value."""
+        query = "MERGE (m:Movie {title: 'The Matrix'}) ON MATCH SET m.status = 'watched'"
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert merge.on_match is not None
+        prop_access, value_expr = merge.on_match.items[0]
+        assert prop_access.property == "status"
+        assert value_expr.value == "watched"
+
+    def test_merge_on_match_with_expression(self):
+        """Parse MERGE with ON MATCH SET with expression."""
+        query = "MERGE (n:Node {id: 1}) ON MATCH SET n.counter = 2 * 5"
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert merge.on_match is not None
+        assert len(merge.on_match.items) == 1
+
+    def test_merge_multiple_patterns_with_on_match(self):
+        """Parse MERGE with multiple patterns and ON MATCH."""
+        query = """
+        MERGE (a:Person {id: 1}), (b:Person {id: 2})
+        ON MATCH SET a.updated = true
+        """
+        ast = parse_cypher(query)
+
+        merge = ast.clauses[0]
+        assert isinstance(merge, MergeClause)
+        assert len(merge.patterns) == 2
+        assert merge.on_match is not None


### PR DESCRIPTION
## Summary

Implements `MERGE ... ON MATCH SET` syntax to complete MERGE enhancements and fully unblock Neo4j example datasets.

This follows PR #65 (ON CREATE SET) and completes Phase 1 of the v0.3.0 roadmap.

## Changes

### 🔧 Grammar
- Extended Lark grammar to support `on_match_clause` rule
- Updated `merge_action` to accept both ON CREATE and ON MATCH
- Case-insensitive keywords (`ON MATCH SET`)

### 📦 AST
- Added `on_match` field to `MergeClause` dataclass
- Type: `SetClause | None` for optional ON MATCH clause
- Updated examples to show combined usage

### 🔄 Parser
- Added `on_match_clause()` transformer
- Updated `merge_clause()` to handle both on_create and on_match
- Maintains backward compatibility

### 📋 Planner
- Updated `Merge` operator with `on_match` field
- Planner passes both `on_create` and `on_match` to operator

### ⚙️ Executor
- Enhanced `_execute_merge()` to track create vs match state
- Conditionally executes SET based on state:
  - `if was_created and op.on_create` → Execute ON CREATE SET
  - `elif not was_created and op.on_match` → Execute ON MATCH SET
- Updated docstring

## Testing

### ✅ Test Coverage

| Category | Tests | Status |
|----------|-------|--------|
| Parser | 10 | ✅ All passing |
| Executor | 11 | ✅ All passing |
| Integration | 11 | ✅ All passing |
| **Total** | **32** | **✅ All passing** |

### 📊 Test Categories

**Parser Tests:**
- Single and multiple property assignments
- Both ON CREATE and ON MATCH together
- Case-insensitive keywords
- Backward compatibility
- Multiple patterns with ON MATCH

**Executor Tests:**
- ON MATCH executes when matching existing nodes
- ON MATCH does NOT execute when creating new nodes
- Both ON CREATE and ON MATCH in same statement
- State tracking across multiple MERGE calls
- Property updates and overwrites

**Integration Tests:**
- Neo4j timestamp tracking patterns
- Counter increment patterns
- Status workflow patterns
- Complex queries with WHERE, RETURN
- Edge cases (null values, idempotency)
- Performance tests (bulk operations)

## Examples

### ON MATCH SET Only
```cypher
MERGE (n:Person {id: 1}) ON MATCH SET n.updated = true
```

### Both ON CREATE and ON MATCH
```cypher
MERGE (n:Person {id: 1})
ON CREATE SET n.created = timestamp()
ON MATCH SET n.updated = timestamp()
```

### Neo4j Timestamp Pattern
```cypher
MERGE (u:User {id: 'user123'})
ON CREATE SET u.created = 100
ON MATCH SET u.lastSeen = 200
```

### Counter Increment Pattern
```cypher
MERGE (p:Page {url: '/home'})
ON CREATE SET p.views = 1
ON MATCH SET p.views = p.views + 1
```

## Verification

- ✅ All 32 new tests pass
- ✅ All 1018 total tests pass (backward compatibility verified)
- ✅ 95.68% coverage (meets threshold)
- ✅ Grammar correctly parses both clauses
- ✅ Executor correctly implements conditional logic
- ✅ No regressions in existing functionality

## Impact

### 🎯 Completes MERGE Enhancement

Together with PR #65 (ON CREATE SET), this fully supports all Neo4j dataset patterns:
- `neo4j-movie-graph` (170 nodes, 250 edges)
- `neo4j-northwind` (1K nodes, 3K edges)
- `neo4j-game-of-thrones` (800 nodes, 3K edges)
- `neo4j-fincen-files` (500 nodes, 1.5K edges)
- `neo4j-twitter` (2K nodes, 8K edges)

### ✨ Real-World Use Cases
- **Timestamp tracking**: Track both creation and last-seen times
- **Counter updates**: Increment view counts, login counts, etc.
- **Status workflows**: Set different properties based on create vs match
- **Upsert patterns**: Common database pattern for insert-or-update

## Related

- Part of v0.3.0 roadmap (Phase 1)
- Follows #65 (MERGE ON CREATE SET)
- Closes #58

## Notes

- Works seamlessly with ON CREATE SET from PR #65
- Maintains full backward compatibility
- Both clauses can be used independently or together
- Grammar extensible for future enhancements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MERGE operations now support ON MATCH SET clauses, enabling different property updates when matching existing nodes versus creating new ones. Complements existing ON CREATE SET functionality.

* **Tests**
  * Added comprehensive test coverage for MERGE with ON MATCH SET, including backward compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->