### PR TITLE
test: unskip arithmetic NULL propagation test

### DIFF
--- a/tests/integration/test_null_handling.py
+++ b/tests/integration/test_null_handling.py
@@ -134,7 +134,6 @@ class TestNullComparisons:
 class TestNullPropagation:
     """Tests for NULL propagation in expressions."""
 
-    @pytest.mark.skip(reason="Arithmetic operators (+, -, *, /) not yet implemented in parser")
     def test_null_in_arithmetic_propagates(self, simple_graph):
         """NULL in arithmetic expression propagates."""
         results = simple_graph.execute("""
@@ -143,7 +142,6 @@ class TestNullPropagation:
         """)
 
         # Charlie has NULL age, arithmetic should propagate NULL
-        # Note: Arithmetic operators not yet implemented
         assert len(results) == 1
         from graphforge.types.values import CypherNull
 


### PR DESCRIPTION
## Summary

Removes the skip marker from `test_null_in_arithmetic_propagates` test which was left behind after arithmetic operators were implemented in v0.2.0.

## Background

Arithmetic operators (+, -, *, /) were implemented in v0.2.0 (#44), but the test for NULL propagation remained skipped with an outdated comment saying "Arithmetic operators not yet implemented in parser".

## Changes

- Remove `@pytest.mark.skip` decorator from `test_null_in_arithmetic_propagates`
- Remove outdated comment about arithmetic operators
- Test now runs and passes correctly

## Testing

**Before:**
- 1108 tests passing, 14 skipped
- Arithmetic NULL test skipped

**After:**
- ✅ 1109 tests passing, 13 skipped
- ✅ Arithmetic NULL test passes
- ✅ All 15 null handling tests pass
- ✅ Coverage: 95.65%
- ✅ `make pre-push` passes

## Test Verification

The test correctly verifies that:
```cypher
MATCH (n:Person {name: 'Charlie'})
RETURN n.age + 10 AS result
```

When `n.age` is NULL, the result is NULL (proper NULL propagation in arithmetic).

## Type

- Test cleanup / maintenance
- No functional changes
- No new features
- No bug fixes (test was just outdated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled test for null value handling in arithmetic operations, allowing verification of null value propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->