### PR TITLE
feat: implement spatial types (point, distance)

### DIFF
--- a/src/graphforge/parser/cypher.lark
+++ b/src/graphforge/parser/cypher.lark
@@ -179,7 +179,7 @@ variable: IDENTIFIER
 TRUE: /true/i
 FALSE: /false/i
 NULL: /null/i
-FUNCTION_NAME: /substring|tointeger|tofloat|tostring|datetime|duration|coalesce|collect|length|minute|second|count|month|lower|upper|trim|year|type|date|time|hour|day|sum|avg|min|max/i
+FUNCTION_NAME: /substring|tointeger|tofloat|tostring|datetime|duration|distance|coalesce|collect|length|minute|second|count|month|lower|upper|point|trim|year|type|date|time|hour|day|sum|avg|min|max/i
 IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_]*/
 
 INT: /[0-9]+/

--- a/src/graphforge/storage/serialization.py
+++ b/src/graphforge/storage/serialization.py
@@ -32,12 +32,14 @@ from graphforge.types.values import (
     CypherBool,
     CypherDate,
     CypherDateTime,
+    CypherDistance,
     CypherDuration,
     CypherFloat,
     CypherInt,
     CypherList,
     CypherMap,
     CypherNull,
+    CypherPoint,
     CypherString,
     CypherTime,
     CypherValue,
@@ -79,6 +81,12 @@ def serialize_cypher_value(value: CypherValue) -> dict:
 
     if isinstance(value, CypherDuration):
         return {"type": "duration", "value": isodate.duration_isoformat(value.value)}
+
+    if isinstance(value, CypherPoint):
+        return {"type": "point", "value": value.value}
+
+    if isinstance(value, CypherDistance):
+        return {"type": "distance", "value": value.value}
 
     if isinstance(value, CypherList):
         return {
@@ -132,6 +140,12 @@ def deserialize_cypher_value(data: dict) -> CypherValue:
 
     if value_type == "duration":
         return CypherDuration(data["value"])
+
+    if value_type == "point":
+        return CypherPoint(data["value"])
+
+    if value_type == "distance":
+        return CypherDistance(data["value"])
 
     if value_type == "list":
         return CypherList([deserialize_cypher_value(item) for item in data["value"]])

--- a/tests/unit/executor/test_spatial_functions.py
+++ b/tests/unit/executor/test_spatial_functions.py
@@ -1,0 +1,235 @@
+"""Unit tests for spatial functions in evaluator.
+
+Tests spatial constructor and calculation functions:
+- point({x, y}) and point({latitude, longitude})
+- distance(point1, point2)
+"""
+
+import pytest
+
+from graphforge.ast.expression import FunctionCall, Literal
+from graphforge.executor.evaluator import ExecutionContext, evaluate_expression
+from graphforge.types.values import (
+    CypherDistance,
+    CypherFloat,
+    CypherPoint,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestPointFunction:
+    """Tests for point() constructor function."""
+
+    def test_point_2d_cartesian(self):
+        """Test point() with 2D Cartesian coordinates."""
+        # Use plain dict which will be converted to CypherMap by evaluator
+        coords = {"x": 1.0, "y": 2.0}
+        func = FunctionCall(name="point", args=[Literal(value=coords)])
+        ctx = ExecutionContext()
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherPoint)
+        assert result.value["x"] == 1.0
+        assert result.value["y"] == 2.0
+        assert result.value["crs"] == "cartesian"
+
+    def test_point_3d_cartesian(self):
+        """Test point() with 3D Cartesian coordinates."""
+        coords = {"x": 1.0, "y": 2.0, "z": 3.0}
+        func = FunctionCall(name="point", args=[Literal(value=coords)])
+        ctx = ExecutionContext()
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherPoint)
+        assert result.value["x"] == 1.0
+        assert result.value["y"] == 2.0
+        assert result.value["z"] == 3.0
+        assert result.value["crs"] == "cartesian-3d"
+
+    def test_point_wgs84(self):
+        """Test point() with WGS-84 geographic coordinates."""
+        coords = {"latitude": 51.5074, "longitude": -0.1278}
+        func = FunctionCall(name="point", args=[Literal(value=coords)])
+        ctx = ExecutionContext()
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherPoint)
+        assert result.value["latitude"] == 51.5074
+        assert result.value["longitude"] == -0.1278
+        assert result.value["crs"] == "wgs-84"
+
+    def test_point_with_integer_coordinates(self):
+        """Test point() accepts integer coordinates."""
+        coords = {"x": 1, "y": 2}
+        func = FunctionCall(name="point", args=[Literal(value=coords)])
+        ctx = ExecutionContext()
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherPoint)
+        assert result.value["x"] == 1.0
+        assert result.value["y"] == 2.0
+
+    def test_point_wrong_arg_count(self):
+        """Test point() with wrong number of arguments."""
+        func = FunctionCall(name="point", args=[])
+        ctx = ExecutionContext()
+
+        with pytest.raises(TypeError, match="POINT expects 1 argument"):
+            evaluate_expression(func, ctx)
+
+    def test_point_non_map_argument(self):
+        """Test point() with non-map argument."""
+        func = FunctionCall(name="point", args=[Literal(value="not a map")])
+        ctx = ExecutionContext()
+
+        with pytest.raises(TypeError, match="POINT expects map argument"):
+            evaluate_expression(func, ctx)
+
+    def test_point_non_numeric_coordinate(self):
+        """Test point() with non-numeric coordinate value."""
+        coords = {"x": "not a number", "y": 2.0}
+        func = FunctionCall(name="point", args=[Literal(value=coords)])
+        ctx = ExecutionContext()
+
+        with pytest.raises(TypeError, match="coordinate 'x' must be numeric"):
+            evaluate_expression(func, ctx)
+
+
+class TestDistanceFunction:
+    """Tests for distance() calculation function."""
+
+    def test_distance_2d_cartesian(self):
+        """Test distance() with 2D Cartesian points."""
+        p1 = CypherPoint({"x": 0.0, "y": 0.0})
+        p2 = CypherPoint({"x": 3.0, "y": 4.0})
+
+        ctx = ExecutionContext()
+        ctx.bind("p1", p1)
+        ctx.bind("p2", p2)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="p1"), Variable(name="p2")])
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherDistance)
+        assert result.value == 5.0  # 3-4-5 triangle
+
+    def test_distance_3d_cartesian(self):
+        """Test distance() with 3D Cartesian points."""
+        p1 = CypherPoint({"x": 0.0, "y": 0.0, "z": 0.0})
+        p2 = CypherPoint({"x": 1.0, "y": 2.0, "z": 2.0})
+
+        ctx = ExecutionContext()
+        ctx.bind("p1", p1)
+        ctx.bind("p2", p2)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="p1"), Variable(name="p2")])
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherDistance)
+        # sqrt(1^2 + 2^2 + 2^2) = sqrt(9) = 3.0
+        assert result.value == 3.0
+
+    def test_distance_same_point_is_zero(self):
+        """Test distance() between same point is zero."""
+        p1 = CypherPoint({"x": 1.0, "y": 2.0})
+        p2 = CypherPoint({"x": 1.0, "y": 2.0})
+
+        ctx = ExecutionContext()
+        ctx.bind("p1", p1)
+        ctx.bind("p2", p2)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="p1"), Variable(name="p2")])
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherDistance)
+        assert result.value == 0.0
+
+    def test_distance_wgs84(self):
+        """Test distance() with WGS-84 geographic points (Haversine)."""
+        # London and Paris (approximately 344 km apart)
+        london = CypherPoint({"latitude": 51.5074, "longitude": -0.1278})
+        paris = CypherPoint({"latitude": 48.8566, "longitude": 2.3522})
+
+        ctx = ExecutionContext()
+        ctx.bind("london", london)
+        ctx.bind("paris", paris)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="london"), Variable(name="paris")])
+
+        result = evaluate_expression(func, ctx)
+
+        assert isinstance(result, CypherDistance)
+        # Approximate distance should be around 340,000-350,000 meters
+        assert 340000 < result.value < 350000
+
+    def test_distance_wrong_arg_count(self):
+        """Test distance() with wrong number of arguments."""
+        func = FunctionCall(name="distance", args=[])
+        ctx = ExecutionContext()
+
+        with pytest.raises(TypeError, match="DISTANCE expects 2 arguments"):
+            evaluate_expression(func, ctx)
+
+    def test_distance_non_point_first_arg(self):
+        """Test distance() with non-point first argument."""
+        p = CypherPoint({"x": 1.0, "y": 2.0})
+
+        ctx = ExecutionContext()
+        ctx.bind("x", CypherFloat(5.0))
+        ctx.bind("p", p)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="x"), Variable(name="p")])
+
+        with pytest.raises(TypeError, match="DISTANCE first argument must be point"):
+            evaluate_expression(func, ctx)
+
+    def test_distance_non_point_second_arg(self):
+        """Test distance() with non-point second argument."""
+        p = CypherPoint({"x": 1.0, "y": 2.0})
+
+        ctx = ExecutionContext()
+        ctx.bind("p", p)
+        ctx.bind("x", CypherFloat(5.0))
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="p"), Variable(name="x")])
+
+        with pytest.raises(TypeError, match="DISTANCE second argument must be point"):
+            evaluate_expression(func, ctx)
+
+    def test_distance_mixed_crs_raises_error(self):
+        """Test distance() with different CRS raises error."""
+        cartesian = CypherPoint({"x": 1.0, "y": 2.0})
+        wgs84 = CypherPoint({"latitude": 51.5, "longitude": -0.1})
+
+        ctx = ExecutionContext()
+        ctx.bind("cart", cartesian)
+        ctx.bind("geo", wgs84)
+
+        from graphforge.ast.expression import Variable
+
+        func = FunctionCall(name="distance", args=[Variable(name="cart"), Variable(name="geo")])
+
+        with pytest.raises(
+            ValueError, match="Cannot calculate distance between points with different CRS"
+        ):
+            evaluate_expression(func, ctx)

--- a/tests/unit/storage/test_spatial_serialization.py
+++ b/tests/unit/storage/test_spatial_serialization.py
@@ -1,0 +1,179 @@
+"""Unit tests for spatial type serialization.
+
+Tests MessagePack serialization/deserialization of spatial types:
+- POINT, DISTANCE
+- Round-trip preservation of values
+- Coordinate format
+"""
+
+import pytest
+
+from graphforge.storage.serialization import (
+    deserialize_cypher_value,
+    deserialize_properties,
+    serialize_cypher_value,
+    serialize_properties,
+)
+from graphforge.types.values import CypherDistance, CypherPoint
+
+pytestmark = pytest.mark.unit
+
+
+class TestSpatialSerialization:
+    """Tests for spatial type serialization."""
+
+    def test_serialize_2d_cartesian_point(self):
+        """Test 2D Cartesian point serialization."""
+        point = CypherPoint({"x": 1.0, "y": 2.0})
+        serialized = serialize_cypher_value(point)
+
+        assert serialized["type"] == "point"
+        assert serialized["value"]["x"] == 1.0
+        assert serialized["value"]["y"] == 2.0
+        assert serialized["value"]["crs"] == "cartesian"
+
+    def test_deserialize_2d_cartesian_point(self):
+        """Test 2D Cartesian point deserialization."""
+        data = {"type": "point", "value": {"x": 1.0, "y": 2.0, "crs": "cartesian"}}
+        deserialized = deserialize_cypher_value(data)
+
+        assert isinstance(deserialized, CypherPoint)
+        assert deserialized.value["x"] == 1.0
+        assert deserialized.value["y"] == 2.0
+        assert deserialized.value["crs"] == "cartesian"
+
+    def test_2d_cartesian_point_roundtrip(self):
+        """Test 2D Cartesian point round-trip serialization."""
+        original = CypherPoint({"x": 1.0, "y": 2.0})
+        serialized = serialize_cypher_value(original)
+        deserialized = deserialize_cypher_value(serialized)
+
+        assert isinstance(deserialized, CypherPoint)
+        assert deserialized.value == original.value
+
+    def test_serialize_3d_cartesian_point(self):
+        """Test 3D Cartesian point serialization."""
+        point = CypherPoint({"x": 1.0, "y": 2.0, "z": 3.0})
+        serialized = serialize_cypher_value(point)
+
+        assert serialized["type"] == "point"
+        assert serialized["value"]["x"] == 1.0
+        assert serialized["value"]["y"] == 2.0
+        assert serialized["value"]["z"] == 3.0
+        assert serialized["value"]["crs"] == "cartesian-3d"
+
+    def test_3d_cartesian_point_roundtrip(self):
+        """Test 3D Cartesian point round-trip serialization."""
+        original = CypherPoint({"x": 1.0, "y": 2.0, "z": 3.0})
+        serialized = serialize_cypher_value(original)
+        deserialized = deserialize_cypher_value(serialized)
+
+        assert isinstance(deserialized, CypherPoint)
+        assert deserialized.value == original.value
+
+    def test_serialize_wgs84_point(self):
+        """Test WGS-84 geographic point serialization."""
+        point = CypherPoint({"latitude": 51.5074, "longitude": -0.1278})
+        serialized = serialize_cypher_value(point)
+
+        assert serialized["type"] == "point"
+        assert serialized["value"]["latitude"] == 51.5074
+        assert serialized["value"]["longitude"] == -0.1278
+        assert serialized["value"]["crs"] == "wgs-84"
+
+    def test_wgs84_point_roundtrip(self):
+        """Test WGS-84 point round-trip serialization."""
+        original = CypherPoint({"latitude": 51.5074, "longitude": -0.1278})
+        serialized = serialize_cypher_value(original)
+        deserialized = deserialize_cypher_value(serialized)
+
+        assert isinstance(deserialized, CypherPoint)
+        assert deserialized.value == original.value
+
+    def test_serialize_distance(self):
+        """Test distance serialization."""
+        distance = CypherDistance(5.0)
+        serialized = serialize_cypher_value(distance)
+
+        assert serialized["type"] == "distance"
+        assert serialized["value"] == 5.0
+
+    def test_deserialize_distance(self):
+        """Test distance deserialization."""
+        data = {"type": "distance", "value": 5.0}
+        deserialized = deserialize_cypher_value(data)
+
+        assert isinstance(deserialized, CypherDistance)
+        assert deserialized.value == 5.0
+
+    def test_distance_roundtrip(self):
+        """Test distance round-trip serialization."""
+        original = CypherDistance(5.0)
+        serialized = serialize_cypher_value(original)
+        deserialized = deserialize_cypher_value(serialized)
+
+        assert isinstance(deserialized, CypherDistance)
+        assert deserialized.value == original.value
+
+
+class TestSpatialPropertiesSerialization:
+    """Tests for properties dict with spatial types."""
+
+    def test_serialize_properties_with_point(self):
+        """Test serializing properties containing POINT."""
+        from graphforge.types.values import CypherString
+
+        properties = {
+            "location": CypherPoint({"x": 1.0, "y": 2.0}),
+            "name": CypherString("Home"),
+        }
+
+        serialized = serialize_properties(properties)
+        assert isinstance(serialized, bytes)
+
+        deserialized = deserialize_properties(serialized)
+        assert isinstance(deserialized["location"], CypherPoint)
+        assert deserialized["location"].value["x"] == 1.0
+        assert deserialized["location"].value["y"] == 2.0
+
+    def test_serialize_properties_with_distance(self):
+        """Test serializing properties containing DISTANCE."""
+        from graphforge.types.values import CypherString
+
+        properties = {
+            "distance_km": CypherDistance(5.5),
+            "route": CypherString("A to B"),
+        }
+
+        serialized = serialize_properties(properties)
+        deserialized = deserialize_properties(serialized)
+
+        assert isinstance(deserialized["distance_km"], CypherDistance)
+        assert deserialized["distance_km"].value == 5.5
+
+    def test_serialize_mixed_spatial_properties(self):
+        """Test serializing properties with multiple spatial types."""
+        from graphforge.types.values import CypherInt, CypherString
+
+        properties = {
+            "start": CypherPoint({"x": 0.0, "y": 0.0}),
+            "end": CypherPoint({"x": 3.0, "y": 4.0}),
+            "distance": CypherDistance(5.0),
+            "name": CypherString("Route"),
+            "stops": CypherInt(2),
+        }
+
+        serialized = serialize_properties(properties)
+        deserialized = deserialize_properties(serialized)
+
+        # Verify all types preserved
+        assert isinstance(deserialized["start"], CypherPoint)
+        assert isinstance(deserialized["end"], CypherPoint)
+        assert isinstance(deserialized["distance"], CypherDistance)
+        assert isinstance(deserialized["name"], CypherString)
+        assert isinstance(deserialized["stops"], CypherInt)
+
+        # Verify values
+        assert deserialized["start"].value["x"] == 0.0
+        assert deserialized["end"].value["x"] == 3.0
+        assert deserialized["distance"].value == 5.0

--- a/tests/unit/types/test_spatial_values.py
+++ b/tests/unit/types/test_spatial_values.py
@@ -1,0 +1,167 @@
+"""Unit tests for spatial CypherValue types.
+
+Tests POINT and DISTANCE types including:
+- Construction from coordinate dictionaries
+- Validation of coordinates
+- Comparison operations
+- Type conversions
+"""
+
+import pytest
+
+from graphforge.types.values import CypherDistance, CypherPoint, CypherType
+
+pytestmark = pytest.mark.unit
+
+
+class TestCypherPoint:
+    """Tests for CypherPoint type."""
+
+    def test_construct_2d_cartesian(self):
+        """Test construction with 2D Cartesian coordinates."""
+        point = CypherPoint({"x": 1.0, "y": 2.0})
+        assert point.type == CypherType.POINT
+        assert point.value["x"] == 1.0
+        assert point.value["y"] == 2.0
+        assert point.value["crs"] == "cartesian"
+
+    def test_construct_3d_cartesian(self):
+        """Test construction with 3D Cartesian coordinates."""
+        point = CypherPoint({"x": 1.0, "y": 2.0, "z": 3.0})
+        assert point.type == CypherType.POINT
+        assert point.value["x"] == 1.0
+        assert point.value["y"] == 2.0
+        assert point.value["z"] == 3.0
+        assert point.value["crs"] == "cartesian-3d"
+
+    def test_construct_wgs84(self):
+        """Test construction with WGS-84 geographic coordinates."""
+        point = CypherPoint({"latitude": 51.5074, "longitude": -0.1278})
+        assert point.type == CypherType.POINT
+        assert point.value["latitude"] == 51.5074
+        assert point.value["longitude"] == -0.1278
+        assert point.value["crs"] == "wgs-84"
+
+    def test_integer_coordinates_converted_to_float(self):
+        """Test that integer coordinates are converted to float."""
+        point = CypherPoint({"x": 1, "y": 2})
+        assert point.value["x"] == 1.0
+        assert point.value["y"] == 2.0
+        assert isinstance(point.value["x"], float)
+
+    def test_invalid_latitude_raises_error(self):
+        """Test that invalid latitude raises ValueError."""
+        with pytest.raises(ValueError, match="Latitude must be between -90 and 90"):
+            CypherPoint({"latitude": 91.0, "longitude": 0.0})
+
+        with pytest.raises(ValueError, match="Latitude must be between -90 and 90"):
+            CypherPoint({"latitude": -91.0, "longitude": 0.0})
+
+    def test_invalid_longitude_raises_error(self):
+        """Test that invalid longitude raises ValueError."""
+        with pytest.raises(ValueError, match="Longitude must be between -180 and 180"):
+            CypherPoint({"latitude": 0.0, "longitude": 181.0})
+
+        with pytest.raises(ValueError, match="Longitude must be between -180 and 180"):
+            CypherPoint({"latitude": 0.0, "longitude": -181.0})
+
+    def test_missing_coordinates_raises_error(self):
+        """Test that missing coordinates raise ValueError."""
+        with pytest.raises(ValueError, match="Point requires either"):
+            CypherPoint({"x": 1.0})  # Missing y
+
+        with pytest.raises(ValueError, match="Point requires either"):
+            CypherPoint({"latitude": 51.5})  # Missing longitude
+
+        with pytest.raises(ValueError, match="Point requires either"):
+            CypherPoint({"foo": 1.0, "bar": 2.0})  # Invalid keys
+
+    def test_repr(self):
+        """Test string representation."""
+        point = CypherPoint({"x": 1.0, "y": 2.0})
+        repr_str = repr(point)
+        assert "CypherPoint" in repr_str
+        assert "'x': 1.0" in repr_str
+        assert "'y': 2.0" in repr_str
+
+
+class TestCypherDistance:
+    """Tests for CypherDistance type."""
+
+    def test_construct_positive_distance(self):
+        """Test construction with positive distance."""
+        distance = CypherDistance(5.0)
+        assert distance.type == CypherType.DISTANCE
+        assert distance.value == 5.0
+
+    def test_construct_zero_distance(self):
+        """Test construction with zero distance."""
+        distance = CypherDistance(0.0)
+        assert distance.type == CypherType.DISTANCE
+        assert distance.value == 0.0
+
+    def test_integer_converted_to_float(self):
+        """Test that integer distance is converted to float."""
+        distance = CypherDistance(5)
+        assert distance.value == 5.0
+        assert isinstance(distance.value, float)
+
+    def test_negative_distance_raises_error(self):
+        """Test that negative distance raises ValueError."""
+        with pytest.raises(ValueError, match="Distance must be non-negative"):
+            CypherDistance(-1.0)
+
+    def test_repr(self):
+        """Test string representation."""
+        distance = CypherDistance(5.0)
+        assert repr(distance) == "CypherDistance(5.0)"
+
+
+class TestPointEquality:
+    """Tests for point equality comparisons."""
+
+    def test_same_cartesian_points_equal(self):
+        """Test that identical Cartesian points are equal."""
+        p1 = CypherPoint({"x": 1.0, "y": 2.0})
+        p2 = CypherPoint({"x": 1.0, "y": 2.0})
+        result = p1.equals(p2)
+        assert result.value is True
+
+    def test_different_cartesian_points_not_equal(self):
+        """Test that different Cartesian points are not equal."""
+        p1 = CypherPoint({"x": 1.0, "y": 2.0})
+        p2 = CypherPoint({"x": 3.0, "y": 4.0})
+        result = p1.equals(p2)
+        assert result.value is False
+
+    def test_2d_and_3d_points_not_equal(self):
+        """Test that 2D and 3D points with same x,y are not equal."""
+        p1 = CypherPoint({"x": 1.0, "y": 2.0})
+        p2 = CypherPoint({"x": 1.0, "y": 2.0, "z": 0.0})
+        result = p1.equals(p2)
+        assert result.value is False
+
+    def test_cartesian_and_wgs84_not_equal(self):
+        """Test that Cartesian and WGS-84 points are not equal."""
+        p1 = CypherPoint({"x": 51.5, "y": -0.1})
+        p2 = CypherPoint({"latitude": 51.5, "longitude": -0.1})
+        result = p1.equals(p2)
+        assert result.value is False
+
+
+class TestDistanceEquality:
+    """Tests for distance equality comparisons."""
+
+    def test_same_distances_equal(self):
+        """Test that identical distances are equal."""
+        d1 = CypherDistance(5.0)
+        d2 = CypherDistance(5.0)
+        result = d1.equals(d2)
+        assert result.value is True
+
+    def test_different_distances_not_equal(self):
+        """Test that different distances are not equal."""
+        d1 = CypherDistance(5.0)
+        d2 = CypherDistance(10.0)
+        result = d1.equals(d2)
+        assert result.value is False


### PR DESCRIPTION
## Summary

Implements 2 spatial types with coordinate parsing to enable geospatial property queries and spatial function support in openCypher.

## Core Implementation

### Spatial Types
- **CypherPoint**: Stores coordinate dictionaries with CRS metadata
  - 2D Cartesian: `{x, y, crs: "cartesian"}`
  - 3D Cartesian: `{x, y, z, crs: "cartesian-3d"}`
  - WGS-84 Geographic: `{latitude, longitude, crs: "wgs-84"}`
- **CypherDistance**: Stores float distance value (non-negative)

### Functions Implemented
**Constructors:**
- `point({x: 1.0, y: 2.0})` - Create Cartesian point
- `point({latitude: 51.5, longitude: -0.1})` - Create geographic point

**Distance Calculation:**
- `distance(point1, point2)` - Calculate distance between points
  - Uses Euclidean formula for Cartesian coordinates
  - Uses Haversine formula for WGS-84 coordinates (great-circle distance)

### Serialization
- MessagePack serialization preserves coordinate dictionaries
- Full round-trip support for all coordinate reference systems
- Coordinate validation on construction (lat/lon ranges)

## Changes

### Modified Files
- `src/graphforge/types/values.py` - 2 spatial type classes with validation
- `src/graphforge/executor/evaluator.py` - point() and distance() functions with Haversine
- `src/graphforge/storage/serialization.py` - Spatial serialization/deserialization
- `src/graphforge/parser/cypher.lark` - Add spatial functions to grammar

### New Test Files
- `tests/unit/types/test_spatial_values.py` - 18 tests for spatial types
- `tests/unit/storage/test_spatial_serialization.py` - 13 serialization tests
- `tests/unit/executor/test_spatial_functions.py` - 16 function tests

## Testing

- **47 new tests added** (all passing)
- **Total: 1,356 tests passing**
- **Coverage: 93.91%** (exceeds 85% threshold)
- All pre-push checks passing (format, lint, type-check, coverage)

## Examples

```cypher
// Store 2D Cartesian points
CREATE (h:Home {
  name: 'My Home',
  location: point({x: 0.0, y: 0.0})
})

// Store WGS-84 geographic points (real-world coordinates)
CREATE (l:City {
  name: 'London',
  location: point({latitude: 51.5074, longitude: -0.1278})
}),
(p:City {
  name: 'Paris',
  location: point({latitude: 48.8566, longitude: 2.3522})
})

// Calculate distances
MATCH (c1:City {name: 'London'}), (c2:City {name: 'Paris'})
RETURN distance(c1.location, c2.location) AS distance_meters
// Returns ~344,000 meters (344 km)

// Find nearby locations
MATCH (home:Home), (place:Place)
WHERE distance(home.location, place.location) < 5.0
RETURN place.name, distance(home.location, place.location) AS dist
ORDER BY dist
```

## Performance Impact

- No performance impact on non-spatial queries
- Haversine formula for WGS-84 is computationally efficient
- Point values stored compactly in MessagePack

## Breaking Changes

None - fully backward compatible with existing code.

## Next Steps

Per approved plan:
1. ✅ Temporal types complete (PR #87)
2. ✅ Spatial types complete (this PR)
3. 🔜 LDBC dataset integration (when needed - user priority: LOW)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added POINT() function to create spatial points with support for 2D/3D Cartesian and WGS-84 geographic coordinates.
* Added DISTANCE() function to calculate distances between spatial points, with automatic handling for multiple coordinate systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->