### PR TITLE
fix: correct codecov-action parameter from 'file' to 'files'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: full-coverage
           name: codecov-full
           fail_ci_if_error: false


### PR DESCRIPTION
Fixes codecov-action@v5 parameter typo causing CI warning.

The codecov-action expects 'files' (plural) not 'file' (singular).

Changed in .github/workflows/test.yml line 151:
  file: ./coverage.xml
to
  files: ./coverage.xml

This removes the warning and ensures the parameter is correctly recognized.