### PR TITLE
fix: TCK harness node pattern property type coercion

### DIFF
--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -592,12 +592,13 @@ def _parse_node_pattern(pattern: str) -> dict:
                 if ":" in pair:
                     key, val = pair.split(":", 1)
                     key = key.strip()
-                    val = val.strip()
-                    # Remove quotes from string values
-                    if val.startswith("'") and val.endswith("'"):
-                        properties[key] = val[1:-1]
+                    parsed = _parse_value(val.strip())
+                    if hasattr(parsed, "value"):
+                        properties[key] = parsed.value
+                    elif isinstance(parsed, CypherNull):
+                        properties[key] = None
                     else:
-                        properties[key] = val
+                        properties[key] = parsed
 
     return {"labels": sorted(labels), "properties": properties}
 


### PR DESCRIPTION
## Summary

- `_parse_node_pattern` was storing property values as raw strings — `{num: 1}` became `{'num': '1'}` while the engine's `NodeRef` comparison produces `{'num': 1}`, causing failures
- Fix uses `_parse_value()` for each property value and unwraps to native Python type, aligning with what `_row_to_comparable` produces for `NodeRef`/`EdgeRef`

## Impact

TCK compliance: **1729 → 1808 passing** (+79 scenarios)

## Issues

Closes #252
Closes #261

## Test plan

- [x] `make pre-push` passing (90.42% total coverage)
- [x] Full TCK run confirms +79 scenarios now passing
- [x] No regressions in previously-passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced property value parsing in test configuration to support more complex data types including lists, maps, and custom node patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->